### PR TITLE
fix theme_newRetro so it loads as ggplot2::theme_set

### DIFF
--- a/R/theme_newRetro.R
+++ b/R/theme_newRetro.R
@@ -43,74 +43,77 @@ new_retro <- function(
         title.size = 15
 ) {
 
-        ggplot2::theme(
-                #Text format:
-                #This sets the font, size, type and colour of text for the chart's title
-                plot.title=ggplot2::element_text(family=font,
-                                                   size=title.size,
-                                                   face="bold",
-                                                   color=main.text.color),
-                #This sets the font, size, type and colour of text for the chart's subtitle, as well as setting a margin between the title and the subtitle
-                plot.subtitle=ggplot2::element_text(family=font,
-                                                      size=subtitle.size,
-                                                      face="bold",
-                                                      color=main.text.color,
-                                                      margin=ggplot2::margin(9,0,9,0)),
-                #Legend format
-                #This sets the position and alignment of the legend, removes a title and backround for it and sets the requirements for any text within the legend. The legend may often need some more manual tweaking when it comes to its exact position based on the plot coordinates.
-                legend.position = legend.position,
-                legend.text.align=0,
-                legend.background=ggplot2::element_blank(),
-                legend.key=ggplot2::element_blank(),
-                legend.text=ggplot2::element_text(family=font,
-                                                    size=legend.text,
-                                                    color=main.text.color),
-                legend.title=ggplot2::element_text(family=font,
-                                                     size=legend.title,
-                                                     color=main.text.color),
+        th <- ggplot2::theme_minimal ()
 
-                #Axis format
-                #This sets the text font, size and colour for the axis test, as well as setting the margins and removes lines and ticks. In some cases, axis lines and axis ticks are things we would want to have in the chart - the cookbook shows examples of how to do so.
-                axis.title=ggplot2::element_text(family=font,
-                                                   size=axis.title.size,
-                                                   color=main.text.color),
-                axis.text=ggplot2::element_text(family=font,
-                                                  size=axis.text.size,
-                                                  color=main.text.color),
-                axis.text.x=ggplot2::element_text(margin=ggplot2::margin(5, b=10)),
-                axis.text.y = ggplot2::element_text(margin=ggplot2::margin(l = 10)),
-                axis.ticks=ggplot2::element_blank(),
-                axis.line=ggplot2::element_blank(),
+        #Text format:
+        #This sets the font, size, type and colour of text for the chart's title
+        th$plot.title=ggplot2::element_text(family=font,
+                                            size=title.size,
+                                            face="bold",
+                                            color=main.text.color)
+        #This sets the font, size, type and colour of text for the chart's subtitle, as well as setting a margin between the title and the subtitle
+        th$plot.subtitle=ggplot2::element_text(family=font,
+                                               size=subtitle.size,
+                                               face="bold",
+                                               color=main.text.color,
+                                               margin=ggplot2::margin(9,0,9,0))
+        #Legend format
+        #This sets the position and alignment of the legend, removes a title and backround for it and sets the requirements for any text within the legend. The legend may often need some more manual tweaking when it comes to its exact position based on the plot coordinates.
+        th$legend.position = legend.position
+        th$legend.text.align=0
+        th$legend.background=ggplot2::element_blank()
+        th$legend.key=ggplot2::element_blank()
+        th$legend.text=ggplot2::element_text(family=font,
+                                             size=legend.text,
+                                             color=main.text.color)
+        th$legend.title=ggplot2::element_text(family=font,
+                                              size=legend.title,
+                                              color=main.text.color)
 
-                #Grid lines
-                #This removes all minor gridlines and adds major y gridlines. In many cases you will want to change this to remove y gridlines and add x gridlines. The cookbook shows you examples for doing so
-                panel.grid.minor=ggplot2::element_blank(),
-                panel.grid.major.y=ggplot2::element_line(linetype=3, color=panel.grid.color, size=0.2),
-                panel.grid.major.x=ggplot2::element_line(linetype=3, color=panel.grid.color, size=0.2),
+        #Axis format
+        #This sets the text font, size and colour for the axis test, as well as setting the margins and removes lines and ticks. In some cases, axis lines and axis ticks are things we would want to have in the chart - the cookbook shows examples of how to do so.
+        th$axis.title.x=ggplot2::element_text(family=font,
+                                              size=axis.title.size,
+                                              color=main.text.color)
+        th$axis.title.y=th$axis.title.x
 
-                #Blank background
-                #This sets the panel background as blank, removing the standard grey ggplot background colour from the plot
-                panel.background = ggplot2::element_rect(
-                        fill=panel.background,
-                        colour = NA
-                ),
-                plot.background = ggplot2::element_rect(
-                        fill = plot.background.color,
-                        colour = NA
-                ),
-                panel.border = ggplot2::element_rect(
-                        color = panel.border.color,
-                        fill = NA,
-                        linetype = "solid",
-                        size = 0.75
-                ),
-                plot.caption = ggplot2::element_text(color=main.text.color),
+        th$axis.text=ggplot2::element_text(family=font,
+                                           size=axis.text.size,
+                                           color=main.text.color)
 
-                #Strip background (#This sets the panel background for facet-wrapped plots to white, removing the standard grey ggplot background colour and sets the title size of the facet-wrap title to font size 22)
-                strip.background = ggplot2::element_rect(fill=panel.background),
-                strip.text= ggplot2::element_text(colour = main.text.color,
-                                                  size  = 12,
-                                                  hjust = 0)
+        th$axis.text.x=ggplot2::element_text(margin=ggplot2::margin(5, b=10))
+        th$axis.text.y = ggplot2::element_text(margin=ggplot2::margin(l = 10))
+        th$axis.ticks=ggplot2::element_blank()
+        th$axis.line=ggplot2::element_blank()
 
+        #Grid lines
+        #This removes all minor gridlines and adds major y gridlines. In many cases you will want to change this to remove y gridlines and add x gridlines. The cookbook shows you examples for doing so
+        th$panel.grid.minor=ggplot2::element_blank()
+        th$panel.grid=ggplot2::element_line(linetype=3, color=panel.grid.color, size=0.2)
+
+        #Blank background
+        #This sets the panel background as blank, removing the standard grey ggplot background colour from the plot
+        th$panel.background = ggplot2::element_rect(
+                                                    fill=panel.background,
+                                                    colour = NA
         )
+        th$plot.background = ggplot2::element_rect(
+                                                   fill = plot.background.color,
+                                                   colour = NA
+        )
+        th$panel.border = ggplot2::element_rect(
+                                                color = panel.border.color,
+                                                fill = NA,
+                                                linetype = "solid",
+                                                size = 0.75
+        )
+        th$plot.caption = ggplot2::element_text(color=main.text.color)
+
+        #Strip background (#This sets the panel background for facet-wrapped plots to white, removing the standard grey ggplot background colour and sets the title size of the facet-wrap title to font size 22)
+        th$strip.background = ggplot2::element_rect(fill=panel.background)
+        th$strip.text= ggplot2::element_text(colour = main.text.color,
+                                             size  = 12,
+                                             hjust = 0)
+
+        return (th)
 }


### PR DESCRIPTION
Thanks so much @moldach for this kick-ass rad package! A pervasive aesthetic boost to my daily life. So much that I've got it as my `.Rprofile` default gg theme, but doing that needs some tweaks which this PR fixes. Before these changes:
``` r
packageVersion("vapoRwave")
#> [1] '0.0.0.9000'
packageVersion("ggplot2")
#> [1] '3.1.1'
ggplot2::theme_set (vapoRwave::new_retro ())
#> Warning: New theme missing the following elements: line, rect, text,
#> axis.title.x, axis.title.x.top, axis.title.y, axis.title.y.right,
#> axis.text.x.top, axis.text.y.right, axis.ticks.length, axis.line.x,
#> axis.line.y, legend.margin, legend.spacing, legend.spacing.x,
#> legend.spacing.y, legend.key.size, legend.key.height, legend.key.width,
#> legend.title.align, legend.direction, legend.justification, legend.box,
#> legend.box.margin, legend.box.background, legend.box.spacing,
#> panel.spacing, panel.spacing.x, panel.spacing.y, panel.grid, panel.ontop,
#> plot.tag, plot.tag.position, plot.margin, strip.placement, strip.text.x,
#> strip.text.y, strip.switch.pad.grid, strip.switch.pad.wrap
```

<sup>Created on 2019-05-09 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

--> because `new_theme()` is firstly quite arguably poorly documented, but does manage to merely say that it "Modifies components of a theme"; it does not create the theme itself. This PR just changes your code by starting with a complete theme, and then modifying the components.

With this PR, the above works silently without warnings.

---

A couple of minor changes:

- your former `axis.title` should be two seperate `axis.title.x` and `axis.title.y` elements
- your former `axis.text.x` and `axis.text.y` should also include master (default) `axis.text`.
- your former `panel.grid.major.x` and `panel.grid.major.y` should only be a single `panel.grid`