### PR TITLE
chore: move from Imports to Suggests :heavy_minus_sign:

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,0 @@
-.First <- function() { library(rstudioapi); library(later); later::later(function() { addTheme("~/.R/themes/Synthwave85.rstheme", apply = TRUE) }, delay = 1) }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 synth-shell/
 slim.report.json
 README.html
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vapoRwave
 Title: Vaporwave themes and color palettes for ggplot2 graphics
-Version: 0.2.0
+Version: 0.3.0
 Authors@R: c(
     person(given = "Matthew", family = "Oldach", role = c("aut", "cre"), email = "moldach686@gmail.com"),
     person("新しい日の誕生 ", comment = "Alien Encounters Typeface", role = c("cph")),
@@ -15,14 +15,14 @@ Description: Giving a bit of 80's flair to ggplot2.
 Imports:
         ggplot2,
         scales,
+        extrafont
+Suggests: 
+        tidyverse,
         knitr,
         gapminder,
         forecast,
         ggcorrplot,
-        WVPlots,
-        extrafont
-Suggests: 
-        tidyverse
+        WVPlots
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Remove `knitr`, `gapminder`, `ggcorrplot`, and `WVPlots` from `Imports:` in the `DESCRIPTION` file as they are only used for vignettes or examples and move them to `Suggests:` section instead (only needed by developers or people wanting to try the vignette)